### PR TITLE
[16.0][IMP] sale_global_discount: calculate lines with fixed taxes should be based on product uom qty

### DIFF
--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -112,9 +112,13 @@ class SaleOrder(models.Model):
                     product=line.product_id,
                     partner=line.order_id.partner_shipping_id,
                 )
-                amount_discounted_tax += sum(
-                    t.get("amount", 0.0) for t in discounted_tax.get("taxes", [])
-                )
+                for tax in discounted_tax.get("taxes", []):
+                    if line.tax_id.browse(tax["id"]).amount_type == "fixed":
+                        amount_discounted_tax += (
+                            tax.get("amount", 0.0) * line.product_uom_qty
+                        )
+                        continue
+                    amount_discounted_tax += tax.get("amount", 0.0)
             order.update(
                 {
                     "amount_untaxed_before_global_discounts": (

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -228,3 +228,40 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(line.price_subtotal, 135)
         self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 234.99)
         self.assertAlmostEqual(self.sale.amount_untaxed, 187.99)
+
+    def test_07_discount_line_with_fixed_taxes(self):
+        # Create a fixed tax and apply on lines
+        fixed_tax = self.safe_copy(self.company_data["default_tax_sale"])
+        fixed_tax.write(
+            {
+                "amount": 5.0,
+                "amount_type": "fixed",
+            }
+        )
+        lines = self.sale.order_line
+        lines.tax_id = [(6, 0, (fixed_tax + self.tax_1 + self.tax_2).ids)]
+        # Based on test_01
+        # 299.99 + (5 * 2) + (5 * 3)
+        self.assertAlmostEqual(self.sale.amount_total, 324.99)
+        # Based on test_01
+        # 60 + (5 * 2) + (5 * 3)
+        self.assertAlmostEqual(self.sale.amount_tax, 75)
+        self.assertAlmostEqual(
+            self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
+        )
+        self.assertAlmostEqual(self.sale.amount_untaxed, 249.99)
+        # Apply a single 20% global discount
+        self.sale.global_discount_ids = self.global_discount_1
+        # Discount is computed over the base and global taxes are computed
+        # according to it line by line with the core method
+        self.assertAlmostEqual(self.sale.amount_global_discount, 50)
+        # Based on test_01
+        # 40 + (5 * 2) + (5 * 3)
+        self.assertAlmostEqual(self.sale.amount_tax, 65.0)
+        self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 249.99)
+        self.assertAlmostEqual(self.sale.amount_untaxed, 199.99)
+        self.assertAlmostEqual(self.sale.amount_total_before_global_discounts, 324.99)
+        self.assertAlmostEqual(self.sale.amount_total, 264.99)
+        self.assertAlmostEqual(
+            self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
+        )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 odoo_test_helper
+odoo-addon-base_global_discount @ git+https://github.com/OCA/server-backend.git@refs/pull/221/head#subdirectory=setup/base_global_discount
+odoo-addon-account_global_discount @ git+https://github.com/OCA/account-invoicing.git@refs/pull/1725/head#subdirectory=setup/account_global_discount


### PR DESCRIPTION
Depend on:
-  `server-backend/pull/221`
-  `account-invoicing/pull/1725`
- `sale-workflow/pull/2343`

Context:
- The taxes with `fixed` type should be matched with [native odoo](https://github.com/odoo/odoo/blob/223d0d57e9ff12145ba2b95041c8fc62eacb3b88/addons/account/models/account_tax.py#L359) 

Notes:
- Will update `test-requirement.txt` on OCA side